### PR TITLE
new db:schema

### DIFF
--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -1,8 +1,198 @@
-import { integer, pgTable, varchar } from 'drizzle-orm/pg-core';
+import { pgTable, text, timestamp, uuid, integer } from 'drizzle-orm/pg-core';
+import { relations } from 'drizzle-orm';
 
-// create a sample "users" table
+// ============================================================================
+// USERS
+// ============================================================================
+
 export const users = pgTable('users', {
-  id: integer('id').primaryKey().generatedAlwaysAsIdentity(),
-  name: varchar('name', { length: 256 }).notNull(),
-  email: varchar('email', { length: 256 }).notNull().unique(),
+  id: uuid('id').defaultRandom().primaryKey(),
+  githubId: text('github_id').notNull().unique(),
+  username: text('username').notNull(),
+  email: text('email'),
+  avatarUrl: text('avatar_url'),
+  accessToken: text('access_token'), // For GitHub API calls
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
 });
+
+export const usersRelations = relations(users, ({ many }) => ({
+  sparks: many(sparks),
+  ideas: many(ideas),
+  projects: many(projects),
+}));
+
+// ============================================================================
+// SPARKS
+// Fleeting thoughts. Capture in seconds. Zero pressure.
+// ============================================================================
+
+export const sparks = pgTable('sparks', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  userId: uuid('user_id')
+    .references(() => users.id, { onDelete: 'cascade' })
+    .notNull(),
+  title: text('title').notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  archivedAt: timestamp('archived_at'),
+});
+
+export const sparksRelations = relations(sparks, ({ one, many }) => ({
+  user: one(users, {
+    fields: [sparks.userId],
+    references: [users.id],
+  }),
+  ideas: many(ideas), // Ideas that originated from this spark
+}));
+
+// ============================================================================
+// IDEAS
+// Expanded sparks. Description, notes, early thinking.
+// ============================================================================
+
+export const ideas = pgTable('ideas', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  userId: uuid('user_id')
+    .references(() => users.id, { onDelete: 'cascade' })
+    .notNull(),
+  sparkOriginId: uuid('spark_origin_id').references(() => sparks.id, {
+    onDelete: 'set null',
+  }),
+  title: text('title').notNull(),
+  description: text('description'),
+  notes: text('notes'),
+  userStory: text('user_story'),
+  techStack: text('tech_stack'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  archivedAt: timestamp('archived_at'),
+});
+
+export const ideasRelations = relations(ideas, ({ one, many }) => ({
+  user: one(users, {
+    fields: [ideas.userId],
+    references: [users.id],
+  }),
+  sparkOrigin: one(sparks, {
+    fields: [ideas.sparkOriginId],
+    references: [sparks.id],
+  }),
+  projects: many(projects), // Projects that originated from this idea
+}));
+
+// ============================================================================
+// PROJECTS
+// Committed to building. Has tasks, statuses, GitHub integration.
+// ============================================================================
+
+export const projects = pgTable('projects', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  userId: uuid('user_id')
+    .references(() => users.id, { onDelete: 'cascade' })
+    .notNull(),
+  ideaOriginId: uuid('idea_origin_id').references(() => ideas.id, {
+    onDelete: 'set null',
+  }),
+  title: text('title').notNull(),
+  description: text('description'),
+  userStory: text('user_story'),
+  techStack: text('tech_stack'),
+  githubRepoUrl: text('github_repo_url'),
+  githubRepoName: text('github_repo_name'),
+  githubRepoOwner: text('github_repo_owner'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  archivedAt: timestamp('archived_at'),
+});
+
+export const projectsRelations = relations(projects, ({ one, many }) => ({
+  user: one(users, {
+    fields: [projects.userId],
+    references: [users.id],
+  }),
+  ideaOrigin: one(ideas, {
+    fields: [projects.ideaOriginId],
+    references: [ideas.id],
+  }),
+  statuses: many(projectStatuses),
+  tasks: many(tasks),
+}));
+
+// ============================================================================
+// PROJECT STATUSES
+// Custom workflow per project. User defines their own.
+// ============================================================================
+
+export const projectStatuses = pgTable('project_statuses', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  projectId: uuid('project_id')
+    .references(() => projects.id, { onDelete: 'cascade' })
+    .notNull(),
+  name: text('name').notNull(),
+  color: text('color').notNull().default('#6b7280'), // Default gray
+  order: integer('order').notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+
+export const projectStatusesRelations = relations(projectStatuses, ({ one, many }) => ({
+  project: one(projects, {
+    fields: [projectStatuses.projectId],
+    references: [projects.id],
+  }),
+  tasks: many(tasks),
+}));
+
+// ============================================================================
+// TASKS
+// Units of work within a project. Can have a linked Git branch.
+// ============================================================================
+
+export const tasks = pgTable('tasks', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  projectId: uuid('project_id')
+    .references(() => projects.id, { onDelete: 'cascade' })
+    .notNull(),
+  statusId: uuid('status_id').references(() => projectStatuses.id, {
+    onDelete: 'set null',
+  }),
+  title: text('title').notNull(),
+  description: text('description'),
+  branchName: text('branch_name'),
+  order: integer('order').notNull().default(0),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+export const tasksRelations = relations(tasks, ({ one }) => ({
+  project: one(projects, {
+    fields: [tasks.projectId],
+    references: [projects.id],
+  }),
+  status: one(projectStatuses, {
+    fields: [tasks.statusId],
+    references: [projectStatuses.id],
+  }),
+}));
+
+// ============================================================================
+// TYPE EXPORTS
+// ============================================================================
+
+export type User = typeof users.$inferSelect;
+export type NewUser = typeof users.$inferInsert;
+
+export type Spark = typeof sparks.$inferSelect;
+export type NewSpark = typeof sparks.$inferInsert;
+
+export type Idea = typeof ideas.$inferSelect;
+export type NewIdea = typeof ideas.$inferInsert;
+
+export type Project = typeof projects.$inferSelect;
+export type NewProject = typeof projects.$inferInsert;
+
+export type ProjectStatus = typeof projectStatuses.$inferSelect;
+export type NewProjectStatus = typeof projectStatuses.$inferInsert;
+
+export type Task = typeof tasks.$inferSelect;
+export type NewTask = typeof tasks.$inferInsert;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "test:ui": "vitest --ui",
     "test:e2e": "playwright test",
     "coverage": "vitest --coverage",
-    "commit": "bash scripts/commit.sh"
+    "commit": "bash scripts/commit.sh",
+    "db:push": "drizzle-kit push",
+    "db:pull": "drizzle-kit pull",
+    "db:generate": "drizzle-kit generate"
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.0.2",

--- a/tests/db.test.tsx
+++ b/tests/db.test.tsx
@@ -1,9 +1,9 @@
 import { config } from 'dotenv';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { neon } from '@neondatabase/serverless';
 import { eq } from 'drizzle-orm';
 import { db } from '@/app/db';
-import { users } from '@/app/db/schema';
+import { users, sparks, ideas, projects, projectStatuses, tasks } from '@/app/db/schema';
 
 config({ path: '.env.local' });
 
@@ -15,31 +15,584 @@ describe('database connection test', () => {
   });
 });
 
-describe('user operations', () => {
-  const testEmail = `test-${Date.now()}@example.com`;
+describe('users table', () => {
+  let testUserId: string;
 
-  it('should create and delete a user', async () => {
-    // Create user
+  afterAll(async () => {
+    if (testUserId) {
+      await db.delete(users).where(eq(users.id, testUserId));
+    }
+  });
+
+  it('should create a new user', async () => {
     const [newUser] = await db
       .insert(users)
       .values({
-        name: 'Test User',
-        email: testEmail,
+        githubId: 'test-github-123',
+        username: 'testuser',
+        email: 'test@example.com',
+        avatarUrl: 'https://example.com/avatar.png',
       })
       .returning();
 
+    testUserId = newUser.id;
+
     expect(newUser).toBeDefined();
-    expect(newUser.name).toBe('Test User');
-    expect(newUser.email).toBe(testEmail);
+    expect(newUser.githubId).toBe('test-github-123');
+    expect(newUser.username).toBe('testuser');
+    expect(newUser.email).toBe('test@example.com');
+    expect(newUser.createdAt).toBeInstanceOf(Date);
+  });
 
-    // Delete user
-    const [deletedUser] = await db.delete(users).where(eq(users.id, newUser.id)).returning();
+  it('should read a user by id', async () => {
+    const [user] = await db.select().from(users).where(eq(users.id, testUserId));
 
-    expect(deletedUser.id).toBe(newUser.id);
+    expect(user).toBeDefined();
+    expect(user.id).toBe(testUserId);
+  });
 
-    // Verify user is deleted
-    const [foundUser] = await db.select().from(users).where(eq(users.id, newUser.id));
+  it('should update a user', async () => {
+    const [updatedUser] = await db
+      .update(users)
+      .set({ username: 'updateduser' })
+      .where(eq(users.id, testUserId))
+      .returning();
 
-    expect(foundUser).toBeUndefined();
+    expect(updatedUser.username).toBe('updateduser');
+  });
+
+  it('should enforce unique githubId constraint', async () => {
+    await expect(
+      db.insert(users).values({
+        githubId: 'test-github-123',
+        username: 'anotheruser',
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('sparks table', () => {
+  let testUserId: string;
+  let testSparkId: string;
+
+  beforeAll(async () => {
+    const [user] = await db
+      .insert(users)
+      .values({
+        githubId: 'spark-test-user',
+        username: 'sparkuser',
+      })
+      .returning();
+    testUserId = user.id;
+  });
+
+  afterAll(async () => {
+    if (testUserId) {
+      await db.delete(users).where(eq(users.id, testUserId));
+    }
+  });
+
+  it('should create a new spark', async () => {
+    const [newSpark] = await db
+      .insert(sparks)
+      .values({
+        userId: testUserId,
+        title: 'My first spark idea',
+      })
+      .returning();
+
+    testSparkId = newSpark.id;
+
+    expect(newSpark).toBeDefined();
+    expect(newSpark.title).toBe('My first spark idea');
+    expect(newSpark.userId).toBe(testUserId);
+    expect(newSpark.archivedAt).toBeNull();
+  });
+
+  it('should read a spark by id', async () => {
+    const [spark] = await db.select().from(sparks).where(eq(sparks.id, testSparkId));
+
+    expect(spark).toBeDefined();
+    expect(spark.title).toBe('My first spark idea');
+  });
+
+  it('should update a spark', async () => {
+    const [updatedSpark] = await db
+      .update(sparks)
+      .set({ title: 'Updated spark title' })
+      .where(eq(sparks.id, testSparkId))
+      .returning();
+
+    expect(updatedSpark.title).toBe('Updated spark title');
+  });
+
+  it('should archive a spark', async () => {
+    const [archivedSpark] = await db
+      .update(sparks)
+      .set({ archivedAt: new Date() })
+      .where(eq(sparks.id, testSparkId))
+      .returning();
+
+    expect(archivedSpark.archivedAt).toBeInstanceOf(Date);
+  });
+
+  it('should cascade delete sparks when user is deleted', async () => {
+    const [tempUser] = await db
+      .insert(users)
+      .values({
+        githubId: 'temp-cascade-user',
+        username: 'tempuser',
+      })
+      .returning();
+
+    await db.insert(sparks).values({
+      userId: tempUser.id,
+      title: 'Temp spark',
+    });
+
+    await db.delete(users).where(eq(users.id, tempUser.id));
+
+    const remainingSparks = await db.select().from(sparks).where(eq(sparks.userId, tempUser.id));
+
+    expect(remainingSparks).toHaveLength(0);
+  });
+});
+
+describe('ideas table', () => {
+  let testUserId: string;
+  let testSparkId: string;
+  let testIdeaId: string;
+
+  beforeAll(async () => {
+    const [user] = await db
+      .insert(users)
+      .values({
+        githubId: 'idea-test-user',
+        username: 'ideauser',
+      })
+      .returning();
+    testUserId = user.id;
+
+    const [spark] = await db
+      .insert(sparks)
+      .values({
+        userId: testUserId,
+        title: 'Origin spark',
+      })
+      .returning();
+    testSparkId = spark.id;
+  });
+
+  afterAll(async () => {
+    if (testUserId) {
+      await db.delete(users).where(eq(users.id, testUserId));
+    }
+  });
+
+  it('should create an idea from a spark', async () => {
+    const [newIdea] = await db
+      .insert(ideas)
+      .values({
+        userId: testUserId,
+        sparkOriginId: testSparkId,
+        title: 'Expanded idea',
+        description: 'This is a detailed description',
+        notes: 'Some notes here',
+        userStory: 'As a user, I want...',
+        techStack: 'Next.js, TypeScript',
+      })
+      .returning();
+
+    testIdeaId = newIdea.id;
+
+    expect(newIdea).toBeDefined();
+    expect(newIdea.title).toBe('Expanded idea');
+    expect(newIdea.sparkOriginId).toBe(testSparkId);
+    expect(newIdea.description).toBe('This is a detailed description');
+  });
+
+  it('should create an idea without a spark origin', async () => {
+    const [newIdea] = await db
+      .insert(ideas)
+      .values({
+        userId: testUserId,
+        title: 'Standalone idea',
+      })
+      .returning();
+
+    expect(newIdea).toBeDefined();
+    expect(newIdea.sparkOriginId).toBeNull();
+
+    await db.delete(ideas).where(eq(ideas.id, newIdea.id));
+  });
+
+  it('should set sparkOriginId to null when origin spark is deleted', async () => {
+    const [tempSpark] = await db
+      .insert(sparks)
+      .values({
+        userId: testUserId,
+        title: 'Temp spark for deletion',
+      })
+      .returning();
+
+    const [ideaWithSpark] = await db
+      .insert(ideas)
+      .values({
+        userId: testUserId,
+        sparkOriginId: tempSpark.id,
+        title: 'Idea linked to temp spark',
+      })
+      .returning();
+
+    await db.delete(sparks).where(eq(sparks.id, tempSpark.id));
+
+    const [updatedIdea] = await db.select().from(ideas).where(eq(ideas.id, ideaWithSpark.id));
+
+    expect(updatedIdea.sparkOriginId).toBeNull();
+
+    await db.delete(ideas).where(eq(ideas.id, ideaWithSpark.id));
+  });
+});
+
+describe('projects table', () => {
+  let testUserId: string;
+  let testIdeaId: string;
+  let testProjectId: string;
+
+  beforeAll(async () => {
+    const [user] = await db
+      .insert(users)
+      .values({
+        githubId: 'project-test-user',
+        username: 'projectuser',
+      })
+      .returning();
+    testUserId = user.id;
+
+    const [idea] = await db
+      .insert(ideas)
+      .values({
+        userId: testUserId,
+        title: 'Origin idea',
+      })
+      .returning();
+    testIdeaId = idea.id;
+  });
+
+  afterAll(async () => {
+    if (testUserId) {
+      await db.delete(users).where(eq(users.id, testUserId));
+    }
+  });
+
+  it('should create a project from an idea', async () => {
+    const [newProject] = await db
+      .insert(projects)
+      .values({
+        userId: testUserId,
+        ideaOriginId: testIdeaId,
+        title: 'My Project',
+        description: 'Project description',
+        githubRepoUrl: 'https://github.com/user/repo',
+        githubRepoName: 'repo',
+        githubRepoOwner: 'user',
+      })
+      .returning();
+
+    testProjectId = newProject.id;
+
+    expect(newProject).toBeDefined();
+    expect(newProject.title).toBe('My Project');
+    expect(newProject.ideaOriginId).toBe(testIdeaId);
+    expect(newProject.githubRepoUrl).toBe('https://github.com/user/repo');
+  });
+
+  it('should create a project without an idea origin', async () => {
+    const [newProject] = await db
+      .insert(projects)
+      .values({
+        userId: testUserId,
+        title: 'Standalone project',
+      })
+      .returning();
+
+    expect(newProject).toBeDefined();
+    expect(newProject.ideaOriginId).toBeNull();
+
+    await db.delete(projects).where(eq(projects.id, newProject.id));
+  });
+
+  it('should update project GitHub info', async () => {
+    const [updatedProject] = await db
+      .update(projects)
+      .set({
+        githubRepoUrl: 'https://github.com/user/new-repo',
+        githubRepoName: 'new-repo',
+      })
+      .where(eq(projects.id, testProjectId))
+      .returning();
+
+    expect(updatedProject.githubRepoUrl).toBe('https://github.com/user/new-repo');
+    expect(updatedProject.githubRepoName).toBe('new-repo');
+  });
+});
+
+describe('projectStatuses table', () => {
+  let testUserId: string;
+  let testProjectId: string;
+  let testStatusId: string;
+
+  beforeAll(async () => {
+    const [user] = await db
+      .insert(users)
+      .values({
+        githubId: 'status-test-user',
+        username: 'statususer',
+      })
+      .returning();
+    testUserId = user.id;
+
+    const [project] = await db
+      .insert(projects)
+      .values({
+        userId: testUserId,
+        title: 'Status test project',
+      })
+      .returning();
+    testProjectId = project.id;
+  });
+
+  afterAll(async () => {
+    if (testUserId) {
+      await db.delete(users).where(eq(users.id, testUserId));
+    }
+  });
+
+  it('should create project statuses with order', async () => {
+    const [todoStatus] = await db
+      .insert(projectStatuses)
+      .values({
+        projectId: testProjectId,
+        name: 'To Do',
+        color: '#ef4444',
+        order: 0,
+      })
+      .returning();
+
+    testStatusId = todoStatus.id;
+
+    const [inProgressStatus] = await db
+      .insert(projectStatuses)
+      .values({
+        projectId: testProjectId,
+        name: 'In Progress',
+        color: '#f59e0b',
+        order: 1,
+      })
+      .returning();
+
+    const [doneStatus] = await db
+      .insert(projectStatuses)
+      .values({
+        projectId: testProjectId,
+        name: 'Done',
+        color: '#22c55e',
+        order: 2,
+      })
+      .returning();
+
+    expect(todoStatus.order).toBe(0);
+    expect(inProgressStatus.order).toBe(1);
+    expect(doneStatus.order).toBe(2);
+  });
+
+  it('should use default color when not specified', async () => {
+    const [status] = await db
+      .insert(projectStatuses)
+      .values({
+        projectId: testProjectId,
+        name: 'Backlog',
+        order: 3,
+      })
+      .returning();
+
+    expect(status.color).toBe('#6b7280');
+
+    await db.delete(projectStatuses).where(eq(projectStatuses.id, status.id));
+  });
+
+  it('should cascade delete statuses when project is deleted', async () => {
+    const [tempProject] = await db
+      .insert(projects)
+      .values({
+        userId: testUserId,
+        title: 'Temp project',
+      })
+      .returning();
+
+    await db.insert(projectStatuses).values({
+      projectId: tempProject.id,
+      name: 'Temp Status',
+      order: 0,
+    });
+
+    await db.delete(projects).where(eq(projects.id, tempProject.id));
+
+    const remainingStatuses = await db
+      .select()
+      .from(projectStatuses)
+      .where(eq(projectStatuses.projectId, tempProject.id));
+
+    expect(remainingStatuses).toHaveLength(0);
+  });
+});
+
+describe('tasks table', () => {
+  let testUserId: string;
+  let testProjectId: string;
+  let testStatusId: string;
+  let testTaskId: string;
+
+  beforeAll(async () => {
+    const [user] = await db
+      .insert(users)
+      .values({
+        githubId: 'task-test-user',
+        username: 'taskuser',
+      })
+      .returning();
+    testUserId = user.id;
+
+    const [project] = await db
+      .insert(projects)
+      .values({
+        userId: testUserId,
+        title: 'Task test project',
+      })
+      .returning();
+    testProjectId = project.id;
+
+    const [status] = await db
+      .insert(projectStatuses)
+      .values({
+        projectId: testProjectId,
+        name: 'To Do',
+        order: 0,
+      })
+      .returning();
+    testStatusId = status.id;
+  });
+
+  afterAll(async () => {
+    if (testUserId) {
+      await db.delete(users).where(eq(users.id, testUserId));
+    }
+  });
+
+  it('should create a task with status', async () => {
+    const [newTask] = await db
+      .insert(tasks)
+      .values({
+        projectId: testProjectId,
+        statusId: testStatusId,
+        title: 'Implement feature X',
+        description: 'Detailed task description',
+        branchName: 'feature/x',
+        order: 0,
+      })
+      .returning();
+
+    testTaskId = newTask.id;
+
+    expect(newTask).toBeDefined();
+    expect(newTask.title).toBe('Implement feature X');
+    expect(newTask.statusId).toBe(testStatusId);
+    expect(newTask.branchName).toBe('feature/x');
+  });
+
+  it('should create a task without status', async () => {
+    const [newTask] = await db
+      .insert(tasks)
+      .values({
+        projectId: testProjectId,
+        title: 'Unassigned task',
+        order: 1,
+      })
+      .returning();
+
+    expect(newTask).toBeDefined();
+    expect(newTask.statusId).toBeNull();
+
+    await db.delete(tasks).where(eq(tasks.id, newTask.id));
+  });
+
+  it('should update task status', async () => {
+    const [inProgressStatus] = await db
+      .insert(projectStatuses)
+      .values({
+        projectId: testProjectId,
+        name: 'In Progress',
+        order: 1,
+      })
+      .returning();
+
+    const [updatedTask] = await db
+      .update(tasks)
+      .set({ statusId: inProgressStatus.id })
+      .where(eq(tasks.id, testTaskId))
+      .returning();
+
+    expect(updatedTask.statusId).toBe(inProgressStatus.id);
+  });
+
+  it('should set statusId to null when status is deleted', async () => {
+    const [tempStatus] = await db
+      .insert(projectStatuses)
+      .values({
+        projectId: testProjectId,
+        name: 'Temp Status',
+        order: 99,
+      })
+      .returning();
+
+    const [taskWithStatus] = await db
+      .insert(tasks)
+      .values({
+        projectId: testProjectId,
+        statusId: tempStatus.id,
+        title: 'Task with temp status',
+        order: 99,
+      })
+      .returning();
+
+    await db.delete(projectStatuses).where(eq(projectStatuses.id, tempStatus.id));
+
+    const [updatedTask] = await db.select().from(tasks).where(eq(tasks.id, taskWithStatus.id));
+
+    expect(updatedTask.statusId).toBeNull();
+
+    await db.delete(tasks).where(eq(tasks.id, taskWithStatus.id));
+  });
+
+  it('should cascade delete tasks when project is deleted', async () => {
+    const [tempProject] = await db
+      .insert(projects)
+      .values({
+        userId: testUserId,
+        title: 'Temp project for tasks',
+      })
+      .returning();
+
+    await db.insert(tasks).values({
+      projectId: tempProject.id,
+      title: 'Task to be deleted',
+      order: 0,
+    });
+
+    await db.delete(projects).where(eq(projects.id, tempProject.id));
+
+    const remainingTasks = await db.select().from(tasks).where(eq(tasks.projectId, tempProject.id));
+
+    expect(remainingTasks).toHaveLength(0);
   });
 });


### PR DESCRIPTION
This pull request introduces a comprehensive overhaul of the database schema in `app/db/schema.ts`, expanding the data model to support a full workflow from user creation to project management. It also adds new database migration and code generation scripts to `package.json` for easier schema management. The changes lay the foundation for features such as capturing sparks (quick ideas), developing them into detailed ideas, and managing projects with custom statuses and tasks.

**Database schema expansion and workflow modeling:**

* Added new tables and relations for `sparks`, `ideas`, `projects`, `project_statuses`, and `tasks` to model the full lifecycle from initial thought to actionable project tasks, including all necessary fields and relationships.
* Refactored the `users` table to use UUIDs, added GitHub integration fields, and standardized timestamp fields for auditing.
* Exported TypeScript types for all major entities (`User`, `Spark`, `Idea`, `Project`, `ProjectStatus`, `Task`) to facilitate type-safe usage throughout the codebase.

**Developer tooling improvements:**

* Added new npm scripts for database migration and code generation (`db:push`, `db:pull`, `db:generate`) to `package.json`, streamlining schema changes and development workflows.